### PR TITLE
xdebug and =2

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Install less:
 Install xhprof:
 > vagrant@debian ~$ xhprof-install
 
+Install xdebug:
+> vagrant@debian ~$ xdebug-install
+
 Troubleshooting
 ---------------
 If you notice an error similar to the following:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -97,21 +97,6 @@ Vagrant.configure(2) do |config|
     composer global require drupal/coder
     composer global require "squizlabs/php_codesniffer=*"
     composer global require terminus/terminus
-
-    # Install Xdebug - Based on article by Anthony Curreri
-    # http://www.mailbeyond.com/phpstorm-vagrant-install-xdebug-php
-    VM_ID_ADDRESS="192.168.33.10"
-    echo "[vagrant provisioning] Installing Xdebug..."
-    sudo mkdir /var/log/xdebug
-    sudo chown www-data:www-data /var/log/xdebug
-    sudo pecl install xdebug
-    XDEBUG_PATH=`find / -name 'xdebug.so'`
-    sudo cp /vagrant/resources/xdebug.ini /tmp/
-    sudo sed -i "s@XDEBUG_PATH@$XDEBUG_PATH@g" /tmp/xdebug.ini
-    sudo sed -i "s@$VM_ID_ADDRESS@$VM_ID_ADDRESS@g" /tmp/xdebug.ini
-    sudo cat /tmp/xdebug.ini >> /etc/php5/fpm/php.ini
-    sudo cat /tmp/xdebug.ini >> /etc/php5/cli/php.ini
-    sudo service apache2 restart # restart apache so latest php config is picked up
 cat << "EOF" >> .bashrc
 export PATH="$HOME/.composer/vendor/bin:/sbin:/usr/sbin:$PATH"
 source $HOME/.composer/vendor/drush/drush/examples/example.bashrc
@@ -154,6 +139,7 @@ alias codespell-install='/vagrant/codespell-install.sh'
 alias compass-install='/vagrant/compass-install.sh'
 alias less-install='/vagrant/less-install.sh'
 alias xhprof-install='/vagrant/xhprof-install.sh'
+alias xdebug-install='/vagrant/xdebug-install.sh'
 EOF
     sed -i 's/^#force_color_prompt/force_color_prompt/g' .bashrc
     sed -i 's/^unset color_prompt/#unset color_prompt/g' .bashrc

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,7 +96,22 @@ Vagrant.configure(2) do |config|
     export COMPOSER_HOME=/home/vagrant/.composer
     composer global require drush/drush:dev-master
     composer global require drupal/coder
-    composer global require squizlabs/PHP_CodeSniffer:\>=2
+    composer global require "squizlabs/php_codesniffer=*"
+
+    # Install Xdebug - Based on article by Anthony Curreri
+    # http://www.mailbeyond.com/phpstorm-vagrant-install-xdebug-php
+    VM_ID_ADDRESS="192.168.33.10"
+    echo "[vagrant provisioning] Installing Xdebug..."
+    sudo mkdir /var/log/xdebug
+    sudo chown www-data:www-data /var/log/xdebug
+    sudo pecl install xdebug
+    XDEBUG_PATH=`find / -name 'xdebug.so'`
+    sudo cp /vagrant/resources/xdebug.ini /tmp/
+    sudo sed -i "s@XDEBUG_PATH@$XDEBUG_PATH@g" /tmp/xdebug.ini
+    sudo sed -i "s@$VM_ID_ADDRESS@$VM_ID_ADDRESS@g" /tmp/xdebug.ini
+    sudo cat /tmp/xdebug.ini >> /etc/php5/fpm/php.ini
+    sudo cat /tmp/xdebug.ini >> /etc/php5/cli/php.ini
+    sudo service apache2 restart # restart apache so latest php config is picked up
 cat << "EOF" >> .bashrc
 export PATH="$HOME/.composer/vendor/bin:/sbin:/usr/sbin:$PATH"
 source $HOME/.composer/vendor/drush/drush/examples/example.bashrc

--- a/xdebug-install.sh
+++ b/xdebug-install.sh
@@ -3,7 +3,7 @@
 # Install Xdebug - Based on article by Anthony Curreri
 # http://www.mailbeyond.com/phpstorm-vagrant-install-xdebug-php
 VM_ID_ADDRESS="192.168.33.10"
-echo "[vagrant provisioning] Installing Xdebug..."
+echo "Installing Xdebug..."
 sudo mkdir /var/log/xdebug
 sudo chown www-data:www-data /var/log/xdebug
 sudo pecl install xdebug

--- a/xdebug-install.sh
+++ b/xdebug-install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install Xdebug - Based on article by Anthony Curreri
+# http://www.mailbeyond.com/phpstorm-vagrant-install-xdebug-php
+VM_ID_ADDRESS="192.168.33.10"
+echo "[vagrant provisioning] Installing Xdebug..."
+sudo mkdir /var/log/xdebug
+sudo chown www-data:www-data /var/log/xdebug
+sudo pecl install xdebug
+XDEBUG_PATH=`find / -name 'xdebug.so'`
+sudo cp /vagrant/xdebug.ini /tmp/
+sudo sed -i "s@XDEBUG_PATH@$XDEBUG_PATH@g" /tmp/xdebug.ini
+sudo sed -i "s@$VM_ID_ADDRESS@$VM_ID_ADDRESS@g" /tmp/xdebug.ini
+sudo cat /tmp/xdebug.ini >> /etc/php5/fpm/php.ini
+sudo cat /tmp/xdebug.ini >> /etc/php5/cli/php.ini
+sudo service apache2 restart # restart apache so latest php config is picked up

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,0 +1,15 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Added to enable Xdebug ;
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+; use the following command to find xdebug.so:
+; find / -name 'xdebug.so' 2> /dev/null
+zend_extension="XDEBUG_PATH"
+xdebug.default_enable = 1
+xdebug.idekey = "pantheon-vagrant"
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 0
+xdebug.remote_port = 9000
+xdebug.remote_handler=dbgp
+xdebug.remote_log="/var/log/xdebug/xdebug.log"
+xdebug.remote_host=VM_ID_ADDRESS ; IDE-Environments IP, from vagrant box.


### PR DESCRIPTION
Adds xdebug and fixes installation of CodeSniffer that was resulting in empty =2 file in home directory
